### PR TITLE
Minor changes for Sale Close

### DIFF
--- a/src/sale/Close/SaleCloseAction.php
+++ b/src/sale/Close/SaleCloseAction.php
@@ -14,6 +14,7 @@ use hiapi\exceptions\domain\RequiredInputException;
 use hiqdev\php\billing\sale\SaleRepositoryInterface;
 use hiqdev\php\billing\plan\Plan;
 use hiqdev\php\billing\sale\Sale;
+use DomainException;
 
 class SaleCloseAction
 {
@@ -36,9 +37,12 @@ class SaleCloseAction
                 null,
                 $command->target,
                 $command->customer,
-                new Plan($command->plan_id, null)
+                new Plan($command->plan->getId(), null)
             )
         );
+        if (!$saleId) {
+            throw new DomainException("Sale does not exists");
+        }
 
         $sale = $this->repo->findById($saleId);
         $sale->close($command->time);

--- a/src/sale/Close/SaleCloseCommand.php
+++ b/src/sale/Close/SaleCloseCommand.php
@@ -12,13 +12,19 @@ namespace hiqdev\billing\hiapi\sale\Close;
 
 use hiapi\commands\BaseCommand;
 use hiapi\validators\IdValidator;
+use hiapi\validators\UsernameValidator;
 use hiqdev\DataMapper\Validator\DateTimeValidator;
+use yii\validators\StringValidator;
 
 class SaleCloseCommand extends BaseCommand
 {
     public $customer_id;
 
+    public $customer_username;
+
     public $plan_id;
+
+    public $plan_name;
 
     public $target_id;
 
@@ -34,8 +40,10 @@ class SaleCloseCommand extends BaseCommand
     {
         return [
             [['customer_id'], IdValidator::class],
+            [['customer_username'], UsernameValidator::class],
 
             [['plan_id'], IdValidator::class],
+            [['plan_name'], StringValidator::class],
 
             [['target_id'], IdValidator::class],
             [['target_id'], 'required'],


### PR DESCRIPTION
Added an Exception, if you are trying to close an already closed sale, rely on PlanLoader when looking for a sale, not the directly passed plan ID so you can find the plan by name