### PR TITLE
Fixs target search by remoteId. If `customer_id` attribute is not exp…

### DIFF
--- a/src/target/Purchase/Action.php
+++ b/src/target/Purchase/Action.php
@@ -95,7 +95,7 @@ class Action
             $spec = (new Specification)->where([
                 'type' => $command->type,
                 'remoteid' => $command->remoteid,
-                'customer_id' => $command->customer_id ?? $command->customer->getId(),
+                'customer_id' => $command->customer->getId(),
             ]);
             $target = $this->targetRepo->findByRemoteid($spec);
         }

--- a/src/target/Purchase/Action.php
+++ b/src/target/Purchase/Action.php
@@ -95,7 +95,7 @@ class Action
             $spec = (new Specification)->where([
                 'type' => $command->type,
                 'remoteid' => $command->remoteid,
-                'customer_id' => $command->customer_id,
+                'customer_id' => $command->customer_id ?? $command->customer->getId(),
             ]);
             $target = $this->targetRepo->findByRemoteid($spec);
         }


### PR DESCRIPTION
…licitly passed, take from loaded customer